### PR TITLE
Fix array to string conversion notice

### DIFF
--- a/src/Service/IqGroupUserManager.php
+++ b/src/Service/IqGroupUserManager.php
@@ -393,7 +393,7 @@ class IqGroupUserManager {
       $ids = $existing_entities;
     }
     unset($user_data[$import_key]);
-    return array_unique($ids);
+    return array_unique($ids, SORT_REGULAR);
   }
 
   /**


### PR DESCRIPTION
## Tasks

- [x] Fix `Warning: Array to string conversion in Drupal\iq_group\Service\IqGroupUserManager->setUserReferenceField() (line 396 of /project/app/public/modules/custom/iq_group/src/Service/IqGroupUserManager.php)`