### PR TITLE
set proper variable order for dispatch method

### DIFF
--- a/src/Form/UserEditForm.php
+++ b/src/Form/UserEditForm.php
@@ -343,7 +343,7 @@ class UserEditForm extends FormBase {
         $groupRoles = array_keys($groupRoles);
         if (!in_array('subscription-lead', $groupRoles)) {
           $this->userManager->addGroupRoleToUser($group, $user, 'subscription-lead');
-          $this->eventDispatcher->dispatch(IqGroupEvents::USER_PROFILE_EDIT, new IqGroupEvent($user));
+          $this->eventDispatcher->dispatch(new IqGroupEvent($user), IqGroupEvents::USER_PROFILE_EDIT);
         }
       }
 
@@ -366,7 +366,7 @@ class UserEditForm extends FormBase {
 
     $this->messenger()->addMessage($this->t('Your profile has been saved.'));
     $user->save();
-    $this->eventDispatcher->dispatch(IqGroupEvents::USER_PROFILE_EDIT, new IqGroupEvent($user));
+    $this->eventDispatcher->dispatch(new IqGroupEvent($user), IqGroupEvents::USER_PROFILE_EDIT);
     // Redirect after saving
     // It would be on the same page as the private resource, so no redirect.
   }


### PR DESCRIPTION
This PR fix an error thrown by the UserEditForm due to wrong variable order on the event dispatch method